### PR TITLE
Fix client WebSocket type declaration

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix the client WebSocket connection declaration so Node `ws` instances type-check for downstream users.
 - Ensure `npm run release:patch` checks out and fast-forwards `master` from `origin/master` before bumping the release version.
 - Rebase the local release commit onto the latest `origin/master` before the final release push to avoid fast-forward rejections.
 - Improve CI test output formatting for easier timeout diagnosis.

--- a/javascript/src/client/connections/web-socket/index.js
+++ b/javascript/src/client/connections/web-socket/index.js
@@ -7,10 +7,10 @@ const logger = new Logger("Scoundrel WebSocket")
 
 // logger.setDebug(true)
 
-export default class WebSocket {
+export default class ClientWebSocket {
   /**
    * Creates a new WebSocket connection handler
-   * @param {WebSocket} ws The WebSocket instance
+   * @param {globalThis.WebSocket | import("ws").WebSocket} ws The WebSocket instance
    */
   constructor(ws) {
     this.ws = ws


### PR DESCRIPTION
## Summary
- rename the client WebSocket wrapper class so generated declarations no longer self-reference the wrapper as the constructor argument
- type the constructor for browser and Node `ws` WebSocket instances
- document the unreleased fix

## Tests
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`