### PR TITLE
Add Scoundrel object replacement API

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add `replaceObject` so clients can explicitly replace a registered object while keeping `registerObject` strict.
 - Fix the client WebSocket connection declaration so Node `ws` instances type-check for downstream users.
 - Ensure `npm run release:patch` checks out and fast-forwards `master` from `origin/master` before bumping the release version.
 - Rebase the local release commit onto the latest `origin/master` before the final release push to avoid fast-forward rejections.

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -109,6 +109,16 @@ expect(config).toEqual({mode: "test"})
 client.unregisterObject("config")
 ```
 
+Replace a registered object explicitly when a stable name should point at the latest instance:
+
+```js
+client.registerObject("screen", {state: "old"})
+client.replaceObject("screen", {state: "current"})
+
+const screen = await client.getObjectResult("screen")
+expect(screen).toEqual({state: "current"})
+```
+
 Reference/result variants:
 
 ```js

--- a/javascript/spec/web-socket-javascript-server-control-spec.js
+++ b/javascript/spec/web-socket-javascript-server-control-spec.js
@@ -58,6 +58,32 @@ describe("scoundrel - web-socket - javascript - server control", () => {
       )
     })
 
+    it("keeps registerObject strict for duplicate object names", async () => {
+      await runWithWebSocketServerClient(
+        async ({client}) => {
+          client.registerObject("testSettings", {value: 1})
+
+          expect(() => client.registerObject("testSettings", {value: 2}))
+            .toThrowError("Object already exists: testSettings")
+        },
+        {enableServerControl: true}
+      )
+    })
+
+    it("replaces registered objects explicitly", async () => {
+      await runWithWebSocketServerClient(
+        async ({client, serverClient}) => {
+          client.registerObject("testSettings", {value: 1})
+          client.replaceObject("testSettings", {value: 2})
+
+          const result = await serverClient.getObjectResult("testSettings")
+
+          expect(result).toEqual({value: 2})
+        },
+        {enableServerControl: true}
+      )
+    })
+
     it("rejects invalid scope names so eval fails loudly", async () => {
       await runWithWebSocketServerClient(
         async ({client, serverClient}) => {

--- a/javascript/src/client/index.js
+++ b/javascript/src/client/index.js
@@ -1182,6 +1182,15 @@ export default class Client {
   }
 
   /**
+   * Replaces a registered object by name, or registers it when it does not exist
+   * @param {string} objectName Object name to replace
+   * @param {any} objectInstance Object instance
+   */
+  replaceObject(objectName, objectInstance) {
+    this._objects[objectName] = objectInstance
+  }
+
+  /**
    * Unregisters an object by name
    * @param {string} objectName Object name to remove
    */


### PR DESCRIPTION
Summary
- add explicit replaceObject support for registered client objects
- keep registerObject strict for duplicate names
- document the replacement API and add changelog entry

Validation
- javascript: npm run test -- spec/web-socket-javascript-server-control-spec.js
- javascript: npm run build
- javascript: npm run typecheck
- javascript: npm run lint
- javascript: npm run test